### PR TITLE
Don't analyse descendants of directories that aren't Python packages

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -44,3 +44,7 @@ History
 
 * Add current working directory to path.
 
+latest
+------
+
+* Don't analyse children of directories that aren't Python packages.

--- a/layer_linter/dependencies.py
+++ b/layer_linter/dependencies.py
@@ -1,7 +1,7 @@
 import logging
 from keyword import iskeyword
 from pydeps.py2depgraph import (
-    MyModuleFinder as PydepsModuleFinder, is_module,
+    MyModuleFinder as PydepsModuleFinder,
     pysource as is_python_file)
 import networkx
 from networkx.algorithms import shortest_path
@@ -133,8 +133,10 @@ class DependencyGraph:
             Generator of Python file names.
         """
         for root, dirs, files in os.walk(directory):
-            # Don't include directories that aren't Python packages.
+            # Don't include directories that aren't Python packages,
+            # nor their subdirectories.
             if '__init__.py' not in files:
+                [dirs.remove(d) for d in list(dirs)]
                 continue
             # Don't include hidden directories.
             dotdirs = [d for d in dirs if d.startswith('.')]

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('HISTORY.rst') as history_file:
 
 requirements = [
     'networkx>=2.1,<3',
-    'pydeps>=1.5.1,<2',
+    'pydeps>=1.5.1,<1.6',
     'PyYAML>=3.12,<4',
     'click>=6.7,<7',
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -29,4 +29,3 @@ deps =
 ;     -r{toxinidir}/requirements.txt
 commands =
     py.test --basetemp={envtmpdir} --cov=layer_linter --cov-report=term --no-cov-on-fail []
-


### PR DESCRIPTION
This is to avoid a problem where there are freestanding Python files/
packages nested within other directories inside your package. This could
happen if, for example, a Python package is installed by npm. They are
not relevant to the internal dependency flow so should be ignored.