### PR TITLE
Fix whitelisted path failing test

### DIFF
--- a/tests/functional/test_get_contracts.py
+++ b/tests/functional/test_get_contracts.py
@@ -46,5 +46,5 @@ def test_get_contracts():
             expected_importer, expected_imported = expected_data['whitelisted_paths'][
                 whitelisted_index]
             assert isinstance(whitelisted_path, ImportPath)
-            assert whitelisted_path.importer == expected_importer
-            assert whitelisted_path.imported == expected_imported
+            assert whitelisted_path.importer == Module(expected_importer)
+            assert whitelisted_path.imported == Module(expected_imported)

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,9 @@ python =
 [flake8]
 max-line-length = 99
 
+[testenv:py36]
+py_backwards = false
+
 [testenv:flake8]
 basepython = python
 deps = flake8


### PR DESCRIPTION
This also turns off pybackwards for Py36 tox command, as
it seems to be causing failing tests to pass (which is why we
didn't notice this one).