### PR TITLE
Officially support python 3.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# IDEs
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: python
 matrix:
     include:
+    - name: "Python 3.7"
+      python: "3.7"
+      env: TOXENV=py37
+      dist: xenial
+      sudo: required
     - name: "Python 3.6"
       python: "3.6"
       env: TOXENV=py36


### PR DESCRIPTION
Add Python 3.7 classifier
Test against 3.7

The default Travis distribution cannot build Python 3.7. So it is necessary to build with the xenial distribution.

I intend to solve the issue #7 with this PR.