### PR TITLE
Fix RST so README renders correctly on PyPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ matrix:
     - name: "Mypy"
       python: "3.6"
       env: TOXENV=mypy
+    - name: "RST linting"
+      python: "3.6"
+      env: TOXENV=rst
 install: pip install -U tox-travis tox-py-backwards
 script: tox
 deploy:

--- a/README.rst
+++ b/README.rst
@@ -61,9 +61,7 @@ organised our project into three subpackages, ``myproject.high``, ``myproject.me
 and ``myproject.low``. These subpackages are known as *layers*. Note: layers must
 have the same parent package (i.e. all be in the same directory). This parent is known as a *container*.
 
-Create a ``layers.yml`` in the root of your project. For example:
-
-.. code-block:: none
+Create a ``layers.yml`` in the root of your project. For example::
 
     My Layers Contract:
       containers:
@@ -82,9 +80,7 @@ Now, from your project root, run::
 
     layer-lint myproject
 
-If your code violates the contract, you will see an error message something like this:
-
-.. code-block:: none
+If your code violates the contract, you will see an error message something like this::
 
     ============
     Layer Linter

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, flake8, layer_lint
+envlist = py36, py37, flake8, layer_lint, rst
 
 [travis]
 python =
@@ -19,6 +19,10 @@ commands = layer-lint layer_linter
 
 [testenv:mypy]
 commands = mypy src/layer_linter
+
+[testenv:rst]
+deps = restructuredtext_lint
+commands = restructuredtext-lint README.rst
 
 [testenv]
 setenv =


### PR DESCRIPTION
Fixes #80 

First: Add an RST linting step to tox (test should fail on Travis)